### PR TITLE
📈 Cache-Control: headers polishing

### DIFF
--- a/etc/nginx/includes/browse_directories.conf
+++ b/etc/nginx/includes/browse_directories.conf
@@ -24,7 +24,6 @@ location ~ ^/__api/files(?<path>/.+)$ {
 
 location ~ ^/browse(?<directory>/.+)?/$ {
   add_header X-A7-Directory "$directory" always;
-  add_header Cache-Control "public, max-age=14400"; # 4 hours
   add_header Cache-Tag "browse";
   add_before_body /a7_browse_body.html;
   add_after_body /a7_browse_directory.html;
@@ -36,7 +35,6 @@ location ~ ^/browse(?<directory>/.+)?/$ {
 
 location ~ ^/browse(?<path>/.+)$ {
   add_header X-A7-File "$path" always;
-  add_header Cache-Control "public, max-age=14400"; # 4 hours
   add_header Cache-Tag "browse";
   add_before_body /a7_browse_body.html;
   add_after_body /a7_browse_asset.html;
@@ -62,7 +60,6 @@ error_page 456 = @json;
 if ( $query_string = "json" ) { return 456; }
 
 location @json {
-  add_header Cache-Control "public, max-age=14400"; # 4 hours
   add_header Cache-Tag "browse";
   autoindex_format json;
 }

--- a/etc/nginx/includes/catalog_queries.conf
+++ b/etc/nginx/includes/catalog_queries.conf
@@ -12,7 +12,6 @@ if ( $query_string = "catalog" ) { return 457; }
 
 location @catalog {
   add_header Content-Type "application/json";
-  # add_header Cache-Control "public, max-age=31536000";
   add_header Cache-Tag "catalog";
   js_content a7.respondWithCatalog;
 }

--- a/etc/nginx/includes/meta_queries.conf
+++ b/etc/nginx/includes/meta_queries.conf
@@ -12,7 +12,6 @@ if ( $query_string = "meta" ) { return 455; }
 
 location @meta {
   add_header Content-Type "application/json";
-  # add_header Cache-Control "public, max-age=31536000";
   add_header Cache-Tag "meta";
   js_content a7.respondWithAssetMeta;
 }


### PR DESCRIPTION
### Description of the Change

Remove Cache-Control: headers on /browse/ location in order to get freshest assets when working on development mode.
Remove unused commented code.

### Quantitative Performance Benefits

Avoid being trolled by our own cache when pushing snapshot. Happens all the time. Trust me it's quantitative.

### Possible Drawbacks

Not having cache on dev regardless the exposition of the asset

### Release Notes

- /browse/* requests are now served with directive `Cache-Control: max-age:0` instead of  `Cache-Control: max-age:14400` 