### PR TITLE
🐛 Make sure we serve only one max-age: directive in multiple Cache-Co…

### DIFF
--- a/etc/nginx/conf.d/a7.conf
+++ b/etc/nginx/conf.d/a7.conf
@@ -94,7 +94,7 @@ server {
 
   # Files configuration
   #
-  add_header Cache-Control "public, max-age=31536000, immutable"; # 1 year
+  add_header Cache-Control "public, immutable"; # 1 year by default, set in includes/cache_expiration.conf
   add_header Cache-Tag "asset";
 
   ## if-env A7_CORS_ALL


### PR DESCRIPTION
### Identify the Bug

#21 

### Description of the Change

Remove max-age directives in Cache-Control explicitly set in conf 

### Alternate Designs

Remove or fine-tune includes/cache_expiration.conf

### Possible Drawbacks

None I can think of.

### Release Notes

- max-age: directive in Cache-Control response headers is now unique