### PR TITLE
🐛 Add cors headers on 302 handled by njs

### DIFF
--- a/edge/src/actions/expand.ts
+++ b/edge/src/actions/expand.ts
@@ -145,6 +145,9 @@ export default function expand (r: NginxHTTPRequest): void {
         return
       }
 
+      r.headersOut['access-control-allow-origin'] = '*'
+      r.headersOut['access-control-allow-headers'] = '*'
+
       r.log(`302: ${newPath}`)
       r.return(302, newPath)
 
@@ -158,6 +161,9 @@ export default function expand (r: NginxHTTPRequest): void {
       }
 
       const newPath = `/${requestedAsset.name}@${requestedAsset.version}/${assetPath}`
+
+      r.headersOut['access-control-allow-origin'] = '*'
+      r.headersOut['access-control-allow-headers'] = '*'
 
       r.log(`302: ${newPath}`)
       r.return(302, newPath)

--- a/edge/src/actions/expand.ts
+++ b/edge/src/actions/expand.ts
@@ -145,8 +145,10 @@ export default function expand (r: NginxHTTPRequest): void {
         return
       }
 
-      r.headersOut['access-control-allow-origin'] = '*'
-      r.headersOut['access-control-allow-headers'] = '*'
+      if (!!process.env.A7_CORS_ALL) {
+        r.headersOut['access-control-allow-origin'] = '*'
+        r.headersOut['access-control-allow-headers'] = '*'
+      }
 
       r.log(`302: ${newPath}`)
       r.return(302, newPath)
@@ -162,8 +164,10 @@ export default function expand (r: NginxHTTPRequest): void {
 
       const newPath = `/${requestedAsset.name}@${requestedAsset.version}/${assetPath}`
 
-      r.headersOut['access-control-allow-origin'] = '*'
-      r.headersOut['access-control-allow-headers'] = '*'
+      if (!!process.env.A7_CORS_ALL) {
+        r.headersOut['access-control-allow-origin'] = '*'
+        r.headersOut['access-control-allow-headers'] = '*'
+      }
 
       r.log(`302: ${newPath}`)
       r.return(302, newPath)

--- a/edge/test/actions/expand.test.ts
+++ b/edge/test/actions/expand.test.ts
@@ -28,6 +28,8 @@ const tests = [{
   expectedHeaders: {
     status: 302,
     location: '/foo@1.3.0/path/to/file.js',
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': '*',
   },
 }, {
   it: 'should handle URI with missing path: /foo@1.3.0',
@@ -35,6 +37,8 @@ const tests = [{
   expectedHeaders: {
     status: 302,
     location: '/foo@1.3.0/path/to/file.js',
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': '*',
   },
 }]
 


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
### Identify the Bug

When requesting an asset with `latest` version (e.g.: `/foo-bar@latest/path-to-file.js`) the redirected location served by njs does not contain any cors headers

### Description of the Change

I propose to duplicate cors configuration set in `include/cors.conf` file in njs module in charge of those redirection requests

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

- Fixed CORS Headers when requesting path requiring a njs redirection
