### PR TITLE
:bug: Support multiple semver prereleases

### DIFF
--- a/edge/src/assets/AssetSpec.ts
+++ b/edge/src/assets/AssetSpec.ts
@@ -40,11 +40,11 @@ export const PRERELEASE = regex `
   \\-                           # hyphen
 
   (?<prerelease>
-    [a-zA-Z\\d]+                  # alphanumerical chars
+    [a-zA-Z\\d-]+                 # alphanumerical chars
 
     (?:                           # optional:
       \\.                         # <dot>
-      [a-zA-Z\\d]+                # alphanumerical chars
+      [a-zA-Z\\d-]+               # alphanumerical chars
     )*
 
   )

--- a/edge/test/assets/AssetNameParser.test.ts
+++ b/edge/test/assets/AssetNameParser.test.ts
@@ -231,5 +231,16 @@ describe('AssetNameParser', () => {
       expect(parsedVersion.version).to.equal('1.4.0')
       expect(parsedVersion.path).to.equal('/baz.js')
     })
+
+    it('should accept multiple prereleases', () => {
+      const parsedVersion = assetNameParser.parseFromUrl('/foo/bar@1.2.3-prerelease1-prerelease2')
+
+      expect(parsedVersion.valid).to.equal(true)
+      expect(parsedVersion.name).to.equal('foo/bar')
+      expect(parsedVersion.namespace).to.equal('foo')
+      expect(parsedVersion.subname).to.equal('bar')
+      expect(parsedVersion.version).to.equal('1.2.3-prerelease1-prerelease2')
+      expect(parsedVersion.path).to.equal(undefined)
+    })
   })
 })


### PR DESCRIPTION
### Identify the Bug

Paths such as `/foo/bar@1.2.3-prerelease1-prerelease2` generate the following error:

> Could not load the catalog: pcre_exec() failed

### Description of the Change

The paths with multiple pre-releases versions are not supported.

### Verification Process

A new unit test covers this edge case.