### PR TITLE
:sparkles: Use rapidoc for api documentation

### DIFF
--- a/html/a7_browse_asset.html
+++ b/html/a7_browse_asset.html
@@ -1,4 +1,4 @@
-</script>
+</template>
 <!--
   ~ Copyright 2021 - Bouygues Telecom
   ~
@@ -20,23 +20,82 @@
   ~ under the License.
   -->
 
+<template id="asset">
+  <div id="preview"></div>
+  <textarea class='textarea' rows='20'></textarea>
+</template>
+
+<template id="apidoc">
+  <rapi-doc
+    id="thedoc"
+    primary-color="#ea5b0f"
+    nav-accent-color="#ea5b0f"
+    theme="light"
+    show-header="false"
+    regular-font="Bouygues Read"
+    schema-style="table"
+    update-route="false"
+    use-path-in-nav-bar="true"
+    show-method-in-nav-bar="true"
+    default-schema-tab="schema"
+    load-fonts="false"
+    allow-spec-file-load="false"
+    allow-spec-file-download="false"
+    use-summary-to-list-example="true"
+  >
+    <script>
+      // const docEl = document.getElementById("thedoc");
+      // docEl.loadSpec(pathname);
+    </script>
+
+    <div slot="overview">
+      <hr class="is-divider" />
+    </div>
+
+    <div slot="nav-logo">
+      <div
+        style="
+          display: grid;
+          grid-template-columns: 48px 5fr;
+          align-items: center;
+        "
+      >
+        <div class="icon is-small" aria-label="Logo Swagger">
+          <svg
+            role="img"
+            style="fill: #85ea2d"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12c6.616 0 12-5.383 12-12S18.616 0 12 0zm0 1.144c5.995 0 10.856 4.86 10.856 10.856 0 5.995-4.86 10.856-10.856 10.856-5.996 0-10.856-4.86-10.856-10.856C1.144 6.004 6.004 1.144 12 1.144zM8.37 5.868a6.707 6.707 0 0 0-.423.005c-.983.056-1.573.517-1.735 1.472-.115.665-.096 1.348-.143 2.017-.013.35-.05.697-.115 1.038-.134.609-.397.798-1.016.83a2.65 2.65 0 0 0-.244.042v1.463c1.126.055 1.278.452 1.37 1.629.033.429-.013.858.015 1.287.018.406.073.808.156 1.2.259 1.075 1.307 1.435 2.575 1.218v-1.283c-.203 0-.383.005-.558 0-.43-.013-.591-.12-.632-.535-.056-.535-.042-1.08-.075-1.62-.064-1.001-.175-1.988-1.153-2.625.503-.37.868-.812.983-1.398.083-.41.134-.821.166-1.237.028-.415-.023-.84.014-1.25.06-.665.102-.937.9-.91.12 0 .235-.017.369-.027v-1.31c-.16 0-.31-.004-.454-.006zm7.593.009a4.247 4.247 0 0 0-.813.06v1.274c.245 0 .434 0 .623.005.328.004.577.13.61.494.032.332.031.669.064 1.006.065.669.101 1.347.217 2.007.102.544.475.95.941 1.283-.817.549-1.057 1.333-1.098 2.215-.023.604-.037 1.213-.069 1.822-.028.554-.222.734-.78.748-.157.004-.31.018-.484.028v1.305c.327 0 .627.019.927 0 .932-.055 1.495-.507 1.68-1.412.078-.498.124-1 .138-1.504.032-.461.028-.927.074-1.384.069-.715.397-1.01 1.112-1.057a.972.972 0 0 0 .199-.046v-1.463c-.12-.014-.204-.027-.291-.032-.536-.023-.804-.203-.937-.71a5.146 5.146 0 0 1-.152-.993c-.037-.618-.033-1.241-.074-1.86-.08-1.192-.794-1.753-1.887-1.786zm-6.89 5.28a.844.844 0 0 0-.083 1.684h.055a.83.83 0 0 0 .877-.78v-.046a.845.845 0 0 0-.83-.858zm2.911 0a.808.808 0 0 0-.834.78c0 .027 0 .05.004.078 0 .503.342.826.859.826.507 0 .826-.332.826-.853-.005-.503-.342-.836-.855-.831zm2.963 0a.861.861 0 0 0-.876.835c0 .47.378.849.849.849h.009c.425.074.853-.337.881-.83.023-.457-.392-.854-.863-.854z"
+            />
+          </svg>
+        </div>
+        <a href="/">
+          <h1 class="title is-size-5 has-text-tertiary-invert">
+            API documentation
+          </h1>
+        </a>
+      </div>
+      <br />
+    </div>
+  </rapi-doc>
+</template>
+
 <script>
+  var content = document.querySelector('#data').content.textContent;
+
   // Instanciate the simple code editor
-  var textarea = document.createElement('textarea');
-  textarea.className = 'textarea';
-  textarea.rows = 20;
-  textarea.textContent = document.querySelector('#data').textContent;
-  document.querySelector('#content').appendChild(textarea);
+  var contentNode = document.createElement('div');
+  // content.className = 'is-unboxed';
+  contentNode.innerHTML = document.querySelector('#asset').innerHTML;
+  document.querySelector('#content').appendChild(contentNode);
+
+  document.querySelector('.textarea').textContent = content;
 
   // Add buttons
   addActionButtons ([
-    ['yaml', 'yml', 'json'].includes(fileextension) && {
-      label: '😎 Swagger UI',
-      title: 'Enable Swagger UI documentation',
-      onclick: function () {
-        enableSwaggerUI();
-      }
-    },
     {
       label: 'Raw',
       title: 'Display the raw file',
@@ -91,7 +150,7 @@
         // set language dynamically according to the file extension
         var fileextension = window.location.pathname.split('.').pop();
         var model = monaco.editor.createModel(
-          document.querySelector('#data').textContent,
+          content,
           undefined,
           monaco.Uri.file('file.' + fileextension)
         );
@@ -104,22 +163,29 @@
 </script>
 
 <script>
-  function enableSwaggerUI () {
-    injectStylesheet('https://unpkg.com/swagger-ui-dist@3.12.1/swagger-ui.css');
-    injectScripts([
-      'https://unpkg.com/swagger-ui-dist@3.12.1/swagger-ui-standalone-preset.js',
-      'https://unpkg.com/swagger-ui-dist@3.12.1/swagger-ui-bundle.js'
-    ], function () {
-      var swaggerui = document.querySelector('#swagger-ui') || document.createElement('div');
-      swaggerui.id = 'swagger-ui';
-      document.querySelector('#content').prepend(swaggerui);
+  try {
+    var jsonDocument = JSON.parse(content);
+    var isSwagger = Boolean(jsonDocument.openapi) || Boolean(jsonDocument.swagger);
 
-      var ui = SwaggerUIBundle({
-        url: pathname,
-        dom_id: '#swagger-ui',
-        deepLinking: true
-      });
-      window.ui = ui;
-    }, 300);
+    function enableSwaggerUI () {
+      injectScripts([
+        'https://unpkg.com/rapidoc@9'
+      ], function () {
+        const doc = document.createElement('div');
+        doc.innerHTML = document.querySelector('#apidoc').innerHTML;
+        document.querySelector('#preview').appendChild(doc);
+
+        const docEl = document.getElementById("thedoc");
+        docEl.loadSpec(pathname);
+      }, 200);
+    }
+
+    // Auto-trigger the swagger UI
+    if (isSwagger) {
+      enableSwaggerUI();
+    }
+  } catch (e) {
+    console.warn('ok');
   }
+
 </script>

--- a/html/a7_browse_body.html
+++ b/html/a7_browse_body.html
@@ -263,4 +263,4 @@ pre {
 </div>
 </div>
 </div>
-<script type="text/template" id="data">
+<template id="data">

--- a/html/a7_browse_directory.html
+++ b/html/a7_browse_directory.html
@@ -22,7 +22,7 @@
 <table class="table is-fullwidth is-narrow">
   <tbody></tbody>
 </table>
-</script>
+</template>
 
 <script>
   // include content


### PR DESCRIPTION
Automatically use [rapidoc](https://github.com/rapi-doc/RapiDoc) when browsing swaggers files, for an enhanced API documentation.