### PR TITLE
Avoid redirection when loading rapidoc@9.3.3 js

### DIFF
--- a/html/a7_browse_asset.html
+++ b/html/a7_browse_asset.html
@@ -164,7 +164,7 @@
   }
 
   function enableApiDocumentation () {
-    injectScript('https://unpkg.com/rapidoc@9', function (event) {
+    injectScript('https://unpkg.com/rapidoc@9.3.3/dist/rapidoc-min.js', function (event) {
       console.debug('Api documentation scripts loaded', { event });
 
       const preview = document.querySelector('#preview');


### PR DESCRIPTION
Rapidoc has 150ms to load before we call its method loadSpec.
When calling dynamic urls such as : https://unpkg.com/rapidoc@9 we can have up to 2 redirections before getting the script, resulting in loadSpec method being called before the script has been downloaded by our browser.
We could also tune the timeout of 150ms in injectScript function if we prefer to keep minor and patch version dynamic

