### PR TITLE
:bug: Ensure the metadata files are created at the right location, if…

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ When requesting unknown or uncertain content, A7 tries its best to handle reques
 
 By relying on [semantic versioning](https://semver.org/) conventions, some [industry standards](#inspirations), and by extending them a bit, A7 supports all the following routing resolutions to the table.
 
-**Also:** Set the `A7_PATH_AUTO_EXPAND_INIT` environment variable to `true` in order to generate the metadata files in all the assets subdirectories.
+**Also:** Set the `A7_PATH_AUTO_EXPAND_INIT` environment variable to `true` or `always` in order to generate the metadata files in all the assets subdirectories (`true` will generate metadata files if a prior existing file; `always` will generate metadata files systematically and overwrite any prior existing file).
 
 #### Fully qualified URI
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       # - A7_CORS_ALL=false
       # Apply semantic-versioning-aware smart redirects (default: true)
       # - A7_PATH_AUTO_EXPAND=false
-      # Initialize/generate the .directory.txt metadata files in every assets subfolders (default: true)
+      # Initialize/generate the .directory.txt metadata files in every assets subfolders (default: true) (values: true, false, always)
       # - A7_PATH_AUTO_EXPAND_INIT=false
       # Only run scripts; do not start the server (default: false)
       # - A7_RUN_SCRIPTS_ONLY=true

--- a/scripts/generate-directories-metadata.sh
+++ b/scripts/generate-directories-metadata.sh
@@ -21,7 +21,7 @@
 # under the License.
 #
 
-if [ "$A7_PATH_AUTO_EXPAND_INIT" != "true" ]; then
+if [ "$A7_PATH_AUTO_EXPAND_INIT" != "true" ] && [ "$A7_PATH_AUTO_EXPAND_INIT" != "always" ]; then
   echo "ENV A7_PATH_AUTO_EXPAND_INIT set to '$A7_PATH_AUTO_EXPAND_INIT'; Let's bypass the directories metadata generation step KTHXBYE."
   return
 fi
@@ -36,7 +36,7 @@ fileEntry () {
   filepath=$2
   hash=$(sha1sum "$filepath" | head -c8)
   size=$(cat "$filepath" | wc -c | sed -e 's/^[[:space:]]*//')
-  servicepath=${filepath#/assets}
+  servicepath=${filepath#$A7_VOLUME_MOUNT_PATH}
   compressedpath=${filepath#$directory/}
   echo "$hash $size $servicepath $compressedpath"
 }
@@ -54,11 +54,12 @@ directoryEntries () {
 
 # For each directory, recursively generate its `.directory.txt` metadata file
 #
-for directory in $(find /assets -type d); do
+for directory in $(find "$A7_VOLUME_MOUNT_PATH" -type d); do
+  echo $directory
   metadata_filepath="$root_dir$directory/.directory.txt"
 
-  # if the metadata file doesn't exist yet
-  if [ ! -e "$metadata_filepath" ]; then
+  # if 👇 we either want to force the metadata generation or 👇 the metadata file doesn't exist yet
+  if [ "$A7_PATH_AUTO_EXPAND_INIT" = "always" ] || [ ! -e "$metadata_filepath" ]; then
     # prepare its folder (when needed)
     mkdir -p "$root_dir$directory"
     # and generate the file


### PR DESCRIPTION
### Context

The metadata files created to support the both the zip feature and search feature have one prerequisite: the use of a conventioned `/assets` mounting volume.

### Problem

If one changes the value of `A7_VOLUME_MOUNT_PATH` (défault value: `/assets`) then the metadata file generation script doesn't have any effect.

### Approach

- Rely on the `A7_VOLUME_MOUNT_PATH` env variable when generating metadata files;
- Add a new option to the `A7_PATH_AUTO_EXPAND_INIT` env var: the value: `always` will force the metadata generation and overwrite any prior existing file.