### PR TITLE
Performance tests

### DIFF
--- a/scripts/generate-directories-metadata.sh
+++ b/scripts/generate-directories-metadata.sh
@@ -35,7 +35,7 @@ fileEntry () {
   directory=$1
   filepath=$2
   hash=$(sha1sum "$filepath" | head -c8)
-  size=$(cat "$filepath" | wc -c | sed -e 's/^[[:space:]]*//')
+  size=$(stat -c "%s" "$filepath")
   servicepath=${filepath#$A7_VOLUME_MOUNT_PATH}
   compressedpath=${filepath#$directory/}
   echo "$hash $size $servicepath $compressedpath"

--- a/scripts/generate-directories-metadata.sh
+++ b/scripts/generate-directories-metadata.sh
@@ -45,8 +45,10 @@ fileEntry () {
 #
 directoryEntries () {
   directory=$1
-  for file in $(find "$directory" -type f -not -name ".directory.txt"); do
-    fileEntry "$directory" "$file"
+  metadata_filepath=$2
+  echo -n "" > "$metadata_filepath"
+  find "$directory" -type f -not -name ".directory.txt" | while read -r file; do
+    fileEntry "$directory" "$file" >> "$metadata_filepath"
   done
 }
 
@@ -54,7 +56,7 @@ directoryEntries () {
 
 # For each directory, recursively generate its `.directory.txt` metadata file
 #
-for directory in $(find "$A7_VOLUME_MOUNT_PATH" -type d); do
+find "$A7_VOLUME_MOUNT_PATH" -type d | while read -r directory; do
   echo $directory
   metadata_filepath="$root_dir$directory/.directory.txt"
 
@@ -63,6 +65,6 @@ for directory in $(find "$A7_VOLUME_MOUNT_PATH" -type d); do
     # prepare its folder (when needed)
     mkdir -p "$root_dir$directory"
     # and generate the file
-    directoryEntries "$directory" > "$metadata_filepath"
+    directoryEntries "$directory" "$metadata_filepath" &
   fi
 done

--- a/test/performance/generate-directories-metadata.sh
+++ b/test/performance/generate-directories-metadata.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# ⚠️ Mac prerequisite: `brew install md5sha1sum`
+
+ROOT_FOLDER=boom
+TIMEFORMAT="⚡ %R"
+
+# initialize the root folder if it does not exist already
+if [ ! -d "$ROOT_FOLDER" ]; then
+  # generate a dense assets directory with random files in every subdirectories
+  echo "Generating a dense assets directory in \"$ROOT_FOLDER\""
+  mkdir -p "$ROOT_FOLDER"/folder-a/asset-{a..z}/dir-{1..10}
+  echo "with random files"
+  find "$ROOT_FOLDER"/* -type d -exec sh -c 'echo $RANDOM > {}/$RANDOM.txt' \;
+
+  # duplicate a lot
+  echo "Duplicate it 25 times"
+  for i in {b..z}; do
+    cp -R "$ROOT_FOLDER"/folder-a "$ROOT_FOLDER"/folder-$i
+  done
+fi
+
+# stats
+echo "folders: $(find "$ROOT_FOLDER" -mindepth 1 -type d | wc -l)"
+echo "files:   $(find "$ROOT_FOLDER" -mindepth 1 -type f | wc -l)"
+echo "size:       $(du -chs "$ROOT_FOLDER" | head -1)"
+
+# run the script
+export A7_PATH_AUTO_EXPAND_INIT=always
+export A7_VOLUME_MOUNT_PATH="$ROOT_FOLDER"
+time ./scripts/generate-directories-metadata.sh


### PR DESCRIPTION
Make the directories metadata generation script 70% faster.

### Comparative table

| Folder | #&nbsp;subfolders | Before&nbsp;<small>(s)</small> | <small>per&nbsp;subdir&nbsp;(ms)</small> | After&nbsp;<small>(s)</small> | <small>per&nbsp;subdir&nbsp;(ms)</small> | Δ |
|:-|:-:|-:|-:|-:|-:|-:|
| `/assets/folder-a/asset-a` | 10 | `2.199` | `220` | `0.661` | `66` | <mark>-70%</mark> |
| `/assets/folder-a` | 286 | `76.377` | `267` | `20.813` | `73` | <mark>-73%</mark> |
| `/assets` | 1 435 | `637.707` | `444` | `175.573` | `122` | <mark>-72%</mark> |