### PR TITLE
:bug: Less CPU intensive regex matching

### DIFF
--- a/edge/src/assets/AssetSpec.ts
+++ b/edge/src/assets/AssetSpec.ts
@@ -109,10 +109,8 @@ export const NAME_PART = regex `
   # leads with a letter
   [a-zA-Z]
 
-  # continues with letters, digits, hyphens, underscores, but:
-  # - no consecutive hyphens
-  # - no trailing hyphen
-  (?:[-_]?[a-zA-Z\\d]+)*
+  # continues with letters, digits, hyphens, underscores
+  [-_a-zA-Z\\d]*
 `
 
 /**

--- a/edge/test/assets/AssetNameParser.test.ts
+++ b/edge/test/assets/AssetNameParser.test.ts
@@ -121,12 +121,6 @@ describe('AssetNameParser', () => {
       expect(parsedVersion.valid).to.equal(false)
     })
 
-    it('should not accept input ending with a dash', () => {
-      const parsedVersion = assetNameParser.parseFromStorageName('trilogy-@0.8.1')
-
-      expect(parsedVersion.valid).to.equal(false)
-    })
-
     it('should accept input ending with a number', () => {
       const parsedVersion = assetNameParser.parseFromStorageName('trilogy2@0.8.1')
 

--- a/edge/test/assets/AssetSpec.test.ts
+++ b/edge/test/assets/AssetSpec.test.ts
@@ -101,18 +101,13 @@ describe('AssetSpec', () => {
         .to.be.undefined
     })
 
-    it('should handle invalid names (has a trailing hyphen)', () => {
-      expect(extractStrict(spec.NAME_PART, 'has-trailing-hyphen-'))
-        .to.be.undefined
-    })
-
-    it('should handle invalid names', () => {
-      expect(extractStrict(spec.NAME_PART, 'with--double-hyphen'))
-        .to.be.undefined
-    })
-
     it('should handle invalid names (has a leading underscore)', () => {
       expect(extractStrict(spec.NAME_PART, '_leading-underscore'))
+        .to.be.undefined
+    })
+
+    it('should handle tralala', () => {
+      expect(extractStrict(spec.STORAGE_VERSION, '_leading-underscore'))
         .to.be.undefined
     })
   })

--- a/test/integration/docker-compose.common.yml
+++ b/test/integration/docker-compose.common.yml
@@ -1,6 +1,6 @@
 services:
   a7:
-    image: bouyguestelecom/a7
+    image: bouyguestelecom/a7:1.7.9
     environment:
       # Path to the assets root directory path (default: /assets)
       - A7_VOLUME_MOUNT_PATH=/assets
@@ -42,3 +42,8 @@ services:
       - ../../etc/nginx/mime.types:/etc/nginx/mime.types:ro
       - ../../etc/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./assets:/assets:ro
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 256M

--- a/test/integration/tests/smart_routing.http
+++ b/test/integration/tests/smart_routing.http
@@ -6,6 +6,7 @@ GET /package@1.3.0/dist/bundle.js
 
 ?? status == 200
 ?? header content-type startsWith text/javascript
+?? duration < 50
 ###
 # @name Handle an URI with missing path
 # @no-redirect
@@ -13,6 +14,7 @@ GET /package@1.3.0
 
 ?? status == 302
 ?? header location == /package@1.3.0/dist/bundle.js
+?? duration < 100
 ###
 # @name Handle URI with incomplete semver (x.y)
 # @no-redirect
@@ -20,6 +22,7 @@ GET /package@1.3/dist/bundle.js
 
 ?? status == 302
 ?? header location == /package@1.3.0/dist/bundle.js
+?? duration < 100
 ###
 # @name Handle URI with incomplete semver (x)
 # @no-redirect
@@ -27,6 +30,7 @@ GET /package@1/dist/bundle.js
 
 ?? status == 302
 ?? header location == /package@1.3.0/dist/bundle.js
+?? duration < 100
 ###
 # @name Handle URI with incomplete semver (pre-release)
 # @no-redirect
@@ -34,8 +38,7 @@ GET /package@1-snapshot/dist/bundle.js
 
 ?? status == 302
 ?? header location == /package@1.3.0-snapshot.20201203171530/dist/bundle.js
-###
-
+?? duration < 100
 ###
 # @name Fetch the latest version of an asset
 # @no-redirect
@@ -43,9 +46,11 @@ GET /package@latest/dist/bundle.js
 
 ?? status == 302
 ?? header location == /package@1.3.0/dist/bundle.js
+?? duration < 100
 ###
 # @name Fetch an unknown URI
 # @no-redirect
 GET /unexpected@1
 
 ?? status == 404
+?? duration < 100


### PR DESCRIPTION
### Context

When the catalog file becomes big enough (more than 3,000 entries), smart routing runs out of steam and a reconciliation can make up to 2 whole seconds.

### Resolution

Speed things up by simplifying the regular expression complexity of package name parts.
Earlier implementation was 100% respectful of the [semver](https://semver.org/) conventions; now we intend to do a bit less work and, for instance, won't ensure a package name does not end with a trailing slash.

This resolution is a tradeoff: here we favor performance over over-quality.