### PR TITLE
🐛 fix displaying file

### DIFF
--- a/html/a7_browse_directory.html
+++ b/html/a7_browse_directory.html
@@ -61,9 +61,7 @@
 
       files = Object.keys(directories).map(function (data) {
         return {
-          name: data,
-          type: 'directory',
-          root: true,
+          ...(directories[data][0] || {}),
           isPackageFolder: directories[data].isPackageFolder
         }
       });


### PR DESCRIPTION
Fix displaying  files linked to the fact that they are considered as folders

Before:
<img width="398" alt="Screenshot 2024-04-11 at 10 58 22" src="https://github.com/BouyguesTelecom/a7/assets/3787789/5b7aa519-b061-4e6a-8dc7-8beae9034c64">

After:
<img width="453" alt="Screenshot 2024-04-11 at 10 57 40" src="https://github.com/BouyguesTelecom/a7/assets/3787789/afebd16e-e27d-4f33-a935-91630178feae">
