### PR TITLE
remove source commenting to reenable zip download through ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ etc/nginx/edge/*
 
 test-output.json
 node_modules
+
+zip/**

--- a/compose.yml
+++ b/compose.yml
@@ -45,3 +45,7 @@ services:
     volumes:
       - ./test/integration/assets:/assets
       - ./etc/nginx/edge:/etc/nginx/edge
+      - ./etc/nginx/includes:/etc/nginx/includes:ro
+      - ./etc/nginx/conf.d:/etc/nginx/conf.d:rw
+      - ./etc/nginx/mime.types:/etc/nginx/mime.types:ro
+      - ./etc/nginx/nginx.conf:/etc/nginx/nginx.conf:ro

--- a/edge/src/helpers/Source.ts
+++ b/edge/src/helpers/Source.ts
@@ -1,6 +1,6 @@
 import Asset from '../assets/Asset'
-import { A7_CORS_ALL, A7_PATH_AUTO_RESOLVE, PUBLIC_ORIGIN } from './Env'
-import { isCssURI, isJsURI, isMinificationRequested, resolveMinifiedURI, resolveNonMinifiedURI } from './Minify'
+// import { A7_CORS_ALL, A7_PATH_AUTO_RESOLVE, PUBLIC_ORIGIN } from './Env'
+// import { isCssURI, isJsURI, isMinificationRequested, resolveMinifiedURI, resolveNonMinifiedURI } from './Minify'
 
 export enum FileAccessMode {
   SERVE_RAW_FILE = 'raw',
@@ -21,48 +21,55 @@ export const commentedSource = (
   source: string,
   fileAccessMode: `${FileAccessMode}`
 ): NjsStringLike => {
-  const isCommentable = isCssURI(r.uri.toString()) || isJsURI(r.uri.toString())
+  return source
 
-  if (!isCommentable) {
-    return source
-  }
+  /**
+   * Adding this comment to the file triggers an error when trying to download packages from the ui
+   * Probably because it modifies the file length and doesn't anymore the size set in the .directory.txt
+   * */
 
-  let comment = ''
-  switch (fileAccessMode) {
-    case 'minified':
-      comment = 'This asset is generated.'
-      break
-    case 'raw':
-      comment = 'This asset is served as-is.'
-      break
-  }
+  //   const isCommentable = isCssURI(r.uri.toString()) || isJsURI(r.uri.toString())
 
-  const publicURI = `${PUBLIC_ORIGIN}/${asset.name}@${asset.version}${asset.path}`
-  const nonMinifiedURI = resolveNonMinifiedURI(publicURI)
-  const minifiedURI = resolveMinifiedURI(nonMinifiedURI)
+  //   if (!isCommentable) {
+  //     return source
+  //   }
 
-  const isMinURI = isMinificationRequested(publicURI)
-  const pinnedURLs = `
- * Pinned URL: (Optimized for Production)
- *   ▶️ Normal:   ${publicURI}${
-    !isMinURI
-      ? `
- *   ⏩ Minified: ${minifiedURI}`
-      : ''
-  }`
+  //   let comment = ''
+  //   switch (fileAccessMode) {
+  //     case 'minified':
+  //       comment = 'This asset is generated.'
+  //       break
+  //     case 'raw':
+  //       comment = 'This asset is served as-is.'
+  //       break
+  //   }
 
-  comment = `/*
- * A7 - ${asset.name}@${asset.version}
- *
- * ${comment}
- * ${pinnedURLs}
- *
- * Details:
- *   👮 CORS:  ${A7_CORS_ALL ? '✅ can be requested from any origin' : '⚠️ can be requested from restricted origins'}
- *   💁 Asset resolution:  ${A7_PATH_AUTO_RESOLVE ? 'resolve and serve' : 'client-side redirect'}
- *
- */
+  //   const publicURI = `${PUBLIC_ORIGIN}/${asset.name}@${asset.version}${asset.path}`
+  //   const nonMinifiedURI = resolveNonMinifiedURI(publicURI)
+  //   const minifiedURI = resolveMinifiedURI(nonMinifiedURI)
 
-`
-  return `${comment}${source}`
+  //   const isMinURI = isMinificationRequested(publicURI)
+  //   const pinnedURLs = `
+  //  * Pinned URL: (Optimized for Production)
+  //  *   ▶️ Normal:   ${publicURI}${
+  //     !isMinURI
+  //       ? `
+  //  *   ⏩ Minified: ${minifiedURI}`
+  //       : ''
+  //   }`
+
+  //   comment = `/*
+  //  * A7 - ${asset.name}@${asset.version}
+  //  *
+  //  * ${comment}
+  //  * ${pinnedURLs}
+  //  *
+  //  * Details:
+  //  *   👮 CORS:  ${A7_CORS_ALL ? '✅ can be requested from any origin' : '⚠️ can be requested from restricted origins'}
+  //  *   💁 Asset resolution:  ${A7_PATH_AUTO_RESOLVE ? 'resolve and serve' : 'client-side redirect'}
+  //  *
+  //  */
+
+  // `
+  //   return `${comment}${source}`
 }

--- a/etc/nginx/includes/zip_directories_server.conf
+++ b/etc/nginx/includes/zip_directories_server.conf
@@ -8,14 +8,13 @@
 map $uri $dirname {
   ~^/(?<captured_dirname>.+)/.directory.txt$ $captured_dirname;
 }
-
 server {
   listen 45538;
 
-  location / {
-    root $mount_path;
+  root $mount_path;
 
-    add_header X-Archive-Files 'zip';
+  location ~* ^(.+\/)\.directory\.txt$ {
+    add_header X-Archive-Files zip;
 
     # set the zip filename sent to the client
     add_header Content-Disposition 'attachment; filename=$dirname.zip';

--- a/test/integration/assets/namespace/.directory.txt
+++ b/test/integration/assets/namespace/.directory.txt
@@ -6,4 +6,4 @@
 - 11 /namespace/package@1.23.4/file.html package@1.23.4/file.html
 - 208 /namespace/package@1.23.4/file.zip package@1.23.4/file.zip
 - 13 /namespace/package@1.23.4/file%20with%20spaces.txt package@1.23.4/file with spaces.txt
-- 14 /namespace/package@1.23.4/file.js package@1.23.4/file.js
+- 14 /namespace/package@1.23.4/file.js namespace/package@1.23.4/file.js


### PR DESCRIPTION
### Identify the Bug

Downloading full packages through the ui is failing. We cannot unzip the received zip

### Description of the Change

Stop adding the comment at the beggining of the js, css file which causes a change in the final length of the file in bytes and might conflict with the length set in the .directory.txt

### Alternate Designs

Add a query param 'no-comment' that can avoid to trigger the creation of this comment on demand, especially when downloading packages. This mean suffixing every path from .directory.txt files with ?no-comment=1

### Release Notes

🐛 fix not being able to download full packages through the ui 


